### PR TITLE
Fix(frontend): Make API URL logic more robust

### DIFF
--- a/frontend/src/utils/apiBaseUrl.ts
+++ b/frontend/src/utils/apiBaseUrl.ts
@@ -1,7 +1,19 @@
-// Returns the correct API base URL for the current environment
+/**
+ * This file determines the base URL for API requests.
+ *
+ * In a production environment, it uses the `VITE_API_BASE_URL_PROD` environment variable.
+ * If this is not set, it defaults to a relative path (empty string), which assumes the API
+ * is served from the same domain as the frontend.
+ *
+ * To set this variable for your production deployment, create a `.env.production` file
+ * in the `frontend` directory and add the following line:
+ * VITE_API_BASE_URL_PROD="https://your-backend-api.com"
+ *
+ * In development, it uses the `VITE_API_BASE_URL` from `.env.development`.
+ */
 const apiBaseUrl =
   import.meta.env.MODE === 'production'
-    ? import.meta.env.VITE_API_BASE_URL_PROD
+    ? import.meta.env.VITE_API_BASE_URL_PROD || '' // Fallback to a relative path
     : import.meta.env.VITE_API_BASE_URL;
 
 export default apiBaseUrl;


### PR DESCRIPTION
The previous implementation would result in an `undefined` apiBaseUrl in production if the `VITE_API_BASE_URL_PROD` environment variable was not set. This would cause a 404 error when making API requests.

This change makes the logic more robust by providing a fallback to a relative path (an empty string). This will prevent the application from crashing and will work correctly in environments where the frontend and backend are served from the same domain.

Additionally, comments have been added to `apiBaseUrl.ts` to guide developers on how to properly configure the environment variables for both production and development environments.