### PR TITLE
Fix ERR_REQUIRE_ESM error in backend tests

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
The `npm test` command was failing with an `ERR_REQUIRE_ESM` error after upgrading `vitest`. This was caused by a module compatibility issue between the project's CommonJS setup and `vitest`'s ESM dependencies.

This commit fixes the issue by updating the `backend/tsconfig.json` to use `module: "NodeNext"` and `moduleResolution: "NodeNext"`. This aligns the project with modern Node.js module resolution and allows `vitest` to run correctly.