### PR TITLE
Implement permanent pool numbering and auto-removal of expired pools

### DIFF
--- a/backend/src/controllers/dashboardController.ts
+++ b/backend/src/controllers/dashboardController.ts
@@ -4,6 +4,7 @@ import Pool from '../database/models/Pool';
 import Bid from '../database/models/Bid';
 import Transaction from '../database/models/Transaction';
 import { IRequestWithUser } from '../middleware/authMiddleware';
+import { removeExpiredPools } from './poolController';
 
 // @desc    Get user dashboard data
 // @route   GET /api/dashboards/user
@@ -11,7 +12,10 @@ import { IRequestWithUser } from '../middleware/authMiddleware';
 export const getUserDashboard = async (req: IRequestWithUser, res: Response) => {
   const userId = req.user?._id;
   try {
-    const pools = await Pool.find({ creator: userId });
+    // Remove expired pools before fetching user data
+    await removeExpiredPools();
+    
+    const pools = await Pool.find({ creator: userId }).sort({ poolNumber: -1 });
     const transactions = await Transaction.find({ user: userId });
     res.json({ pools, transactions });
   } catch (error) {

--- a/backend/src/database/models/Pool.ts
+++ b/backend/src/database/models/Pool.ts
@@ -9,6 +9,7 @@ interface IPool extends Document {
   creator: Schema.Types.ObjectId;
   members: Schema.Types.ObjectId[];
   status: 'open' | 'closed' | 'completed';
+  poolNumber: number;
 }
 
 const poolSchema: Schema = new Schema({
@@ -48,6 +49,11 @@ const poolSchema: Schema = new Schema({
     type: String,
     enum: ['open', 'closed', 'completed'],
     default: 'open',
+  },
+  poolNumber: {
+    type: Number,
+    required: true,
+    unique: true,
   },
 }, {
   timestamps: true,

--- a/backend/tests/controllers/poolController.test.ts
+++ b/backend/tests/controllers/poolController.test.ts
@@ -41,8 +41,8 @@ describe('Pool Controller Integration Tests', () => {
     };
 
     // Setup Pool static methods
-    vi.mocked(Pool.findOne) = vi.fn();
-    vi.mocked(Pool.findById) = vi.fn();
+    Pool.findOne = vi.fn();
+    Pool.findById = vi.fn();
 
     mockReq = {
       user: mockUser,

--- a/backend/tests/controllers/poolController.test.ts
+++ b/backend/tests/controllers/poolController.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { createPool, joinPool } from '../../src/controllers/poolController';
 import Pool from '../../src/database/models/Pool';
 import { IRequestWithUser } from '../../src/middleware/authMiddleware';
@@ -14,6 +14,7 @@ vi.mock('../../src/utils/asyncHandler', () => ({
 describe('Pool Controller Integration Tests', () => {
   let mockReq: Partial<IRequestWithUser>;
   let mockRes: Partial<Response>;
+  let mockNext: NextFunction;
   let mockUser: any;
   let mockPool: any;
 
@@ -54,6 +55,8 @@ describe('Pool Controller Integration Tests', () => {
       status: vi.fn().mockReturnThis(),
       json: vi.fn().mockReturnThis(),
     };
+
+    mockNext = vi.fn();
   });
 
   describe('createPool', () => {
@@ -76,7 +79,7 @@ describe('Pool Controller Integration Tests', () => {
       mockPool.save.mockResolvedValue(mockPool); // Return the pool itself
 
       // Act
-      await createPool(mockReq as IRequestWithUser, mockRes as Response);
+      await createPool(mockReq as IRequestWithUser, mockRes as Response, mockNext);
 
       // Assert
       expect(Pool.findOne).toHaveBeenCalled();
@@ -104,7 +107,7 @@ describe('Pool Controller Integration Tests', () => {
 
       // Act & Assert
       await expect(
-        createPool(mockReq as IRequestWithUser, mockRes as Response)
+        createPool(mockReq as IRequestWithUser, mockRes as Response, mockNext)
       ).rejects.toThrow('Please provide all required fields');
 
       expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -123,7 +126,7 @@ describe('Pool Controller Integration Tests', () => {
 
       // Act & Assert
       await expect(
-        createPool(mockReq as IRequestWithUser, mockRes as Response)
+        createPool(mockReq as IRequestWithUser, mockRes as Response, mockNext)
       ).rejects.toThrow('User not authenticated');
 
       expect(mockRes.status).toHaveBeenCalledWith(401);
@@ -140,7 +143,7 @@ describe('Pool Controller Integration Tests', () => {
       vi.mocked(Pool.findById).mockResolvedValue(mockPool);
 
       // Act
-      await joinPool(mockReq as IRequestWithUser, mockRes as Response);
+      await joinPool(mockReq as IRequestWithUser, mockRes as Response, mockNext);
 
       // Assert
       expect(Pool.findById).toHaveBeenCalledWith(mockPool._id.toString());
@@ -155,7 +158,7 @@ describe('Pool Controller Integration Tests', () => {
 
       // Act & Assert
       await expect(
-        joinPool(mockReq as IRequestWithUser, mockRes as Response)
+        joinPool(mockReq as IRequestWithUser, mockRes as Response, mockNext)
       ).rejects.toThrow('Pool not found');
 
       expect(mockRes.status).toHaveBeenCalledWith(404);
@@ -168,7 +171,7 @@ describe('Pool Controller Integration Tests', () => {
 
       // Act & Assert
       await expect(
-        joinPool(mockReq as IRequestWithUser, mockRes as Response)
+        joinPool(mockReq as IRequestWithUser, mockRes as Response, mockNext)
       ).rejects.toThrow('You are already a member of this pool');
 
       expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -181,7 +184,7 @@ describe('Pool Controller Integration Tests', () => {
 
       // Act & Assert
       await expect(
-        joinPool(mockReq as IRequestWithUser, mockRes as Response)
+        joinPool(mockReq as IRequestWithUser, mockRes as Response, mockNext)
       ).rejects.toThrow('User not authenticated');
 
       expect(mockRes.status).toHaveBeenCalledWith(401);
@@ -194,7 +197,7 @@ describe('Pool Controller Integration Tests', () => {
       vi.mocked(Pool.findById).mockResolvedValue(mockPool);
 
       // Act
-      await joinPool(mockReq as IRequestWithUser, mockRes as Response);
+      await joinPool(mockReq as IRequestWithUser, mockRes as Response, mockNext);
 
       // Assert
       expect(mockPool.members).toHaveLength(2);

--- a/frontend/src/components/PoolCard.tsx
+++ b/frontend/src/components/PoolCard.tsx
@@ -13,14 +13,14 @@ export interface Pool {
   members: string[];
   createdAt: string;
   updatedAt: string;
+  poolNumber: number;
 }
 
 interface PoolCardProps {
   pool: Pool;
-  poolNumber: number;
 }
 
-const PoolCard: React.FC<PoolCardProps> = ({ pool, poolNumber }) => {
+const PoolCard: React.FC<PoolCardProps> = ({ pool }) => {
   const [memberCount, setMemberCount] = useState(pool.members.length);
   const [isJoined, setIsJoined] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -64,7 +64,7 @@ const PoolCard: React.FC<PoolCardProps> = ({ pool, poolNumber }) => {
 
   return (
     <div className={styles.poolCard}>
-      <div className={styles.poolNumber}>{poolNumber}</div>
+      <div className={styles.poolNumber}>{pool.poolNumber}</div>
       <h3>{pool.title}</h3>
       <p>{pool.description}</p>
       <div className={styles.details}>

--- a/frontend/src/pages/AllPools.tsx
+++ b/frontend/src/pages/AllPools.tsx
@@ -49,8 +49,8 @@ const AllPoolsPage = () => {
   } else {
     content = (
       <div className={styles.poolsGrid}>
-        {pools.map((pool, index) => (
-          <PoolCard key={pool._id} pool={pool} poolNumber={index + 1} />
+        {pools.map((pool) => (
+          <PoolCard key={pool._id} pool={pool} />
         ))}
       </div>
     );

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -8,6 +8,7 @@ interface IPool {
   amount: number;
   status: string;
   location: string;
+  poolNumber: number;
 }
 
 interface ITransaction {
@@ -75,9 +76,9 @@ const UserDashboard: React.FC = () => {
 
       <section className={styles.section}>
         <h2 className={styles.sectionTitle}>My Pools</h2>
-        {pools.length > 0 ? pools.map((pool, index) => (
+        {pools.length > 0 ? pools.map((pool) => (
           <div key={pool._id} className={styles.card}>
-            <div className={styles.poolNumber}>{index + 1}</div>
+            <div className={styles.poolNumber}>{pool.poolNumber}</div>
             <h3>{pool.title}</h3>
             <p>Amount: ${pool.amount}</p>
             <p>Status: {pool.status}</p>


### PR DESCRIPTION
- Add poolNumber field to Pool model with unique constraint
- Auto-assign incremental pool numbers on creation (1, 2, 3...)
- Pool numbers are permanent and never change once assigned
- Implement auto-removal of expired pools (past closing date)
- Sort pools by poolNumber in descending order (newest numbers first)
- Update frontend interfaces to use permanent poolNumber from backend
- Remove index-based numbering from frontend components
- Add cleanup function to remove expired pools before fetching data
- Export removeExpiredPools for use in dashboard controller